### PR TITLE
Use SSLv23 for ifmap client as SSLv3 is no more supported by openjdk

### DIFF
--- a/src/ifmap/client/ifmap_channel.cc
+++ b/src/ifmap/client/ifmap_channel.cc
@@ -121,7 +121,7 @@ void IFMapChannel::ChannelUseCertAuth(const std::string& certstore)
 IFMapChannel::IFMapChannel(IFMapManager *manager, const std::string& user,
                 const std::string& passwd, const std::string& certstore)
     : manager_(manager), resolver_(*(manager->io_service())),
-      ctx_(*(manager->io_service()), boost::asio::ssl::context::sslv3_client),
+      ctx_(*(manager->io_service()), boost::asio::ssl::context::sslv23_client),
       io_strand_(*(manager->io_service())),
       ssrc_socket_(new SslStream((*manager->io_service()), ctx_)),
       arc_socket_(new SslStream((*manager->io_service()), ctx_)),
@@ -299,6 +299,8 @@ void IFMapChannel::DoSslHandshakeInMainThr(bool is_ssrc) {
     CHECK_CONCURRENCY_MAIN_THR();
     SslStream *socket =
         ((is_ssrc == true) ? ssrc_socket_.get() : arc_socket_.get());
+     // Calling openssl api directly because boost doesn't provide a way to set the cipher
+    SSL_set_cipher_list(socket->native_handle(),"RC4-SHA");
 
     // handshake as 'client'
     socket->async_handshake(boost::asio::ssl::stream_base::client,


### PR DESCRIPTION
SSLv3 is no longer supported so changing it to SSLv23 in ifmap client