### PR TITLE
SSLv23 is no more supported in newer version of openjdk so switching …

### DIFF
--- a/src/ifmap/client/ifmap_channel.cc
+++ b/src/ifmap/client/ifmap_channel.cc
@@ -121,7 +121,7 @@ void IFMapChannel::ChannelUseCertAuth(const std::string& certstore)
 IFMapChannel::IFMapChannel(IFMapManager *manager, const std::string& user,
                 const std::string& passwd, const std::string& certstore)
     : manager_(manager), resolver_(*(manager->io_service())),
-      ctx_(*(manager->io_service()), boost::asio::ssl::context::sslv23_client),
+      ctx_(*(manager->io_service()), boost::asio::ssl::context::tlsv1_client),
       io_strand_(*(manager->io_service())),
       ssrc_socket_(new SslStream((*manager->io_service()), ctx_)),
       arc_socket_(new SslStream((*manager->io_service()), ctx_)),


### PR DESCRIPTION
…to tlsv1