### PR TITLE
Patch to fix no such process for contrail-api and contrail-discovery

### DIFF
--- a/src/config/api-server/contrail-api.initd.supervisord
+++ b/src/config/api-server/contrail-api.initd.supervisord
@@ -3,4 +3,9 @@
 # chkconfig: 2345 99 01
 # description: Juniper Network Virtualization API
 
-supervisorctl -s unix:///tmp/supervisord_config.sock ${1} `basename ${0}`
+processname=`basename ${0}`
+for prs in `supervisorctl -s unix:///tmp/supervisord_config.sock status | grep $processname | awk '{ print $1}'`
+do
+ supervisorctl -s unix:///tmp/supervisord_config.sock ${1} $prs
+done
+

--- a/src/discovery/contrail-discovery.initd.supervisord
+++ b/src/discovery/contrail-discovery.initd.supervisord
@@ -3,4 +3,9 @@
 # chkconfig: 2345 99 01
 # description: Juniper Network Virtualization Discovery Server
 
-supervisorctl -s unix:///tmp/supervisord_config.sock ${1} `basename ${0}`
+processname=`basename ${0}`
+for prs in `supervisorctl -s unix:///tmp/supervisord_config.sock status | grep $processname | awk '{ print $1}'`
+do
+ supervisorctl -s unix:///tmp/supervisord_config.sock ${1} $prs
+done
+


### PR DESCRIPTION
Restarting contrail-api in R2.1 using 'service contrail-api restart' fails with no such process found. This is because supervisor spawns a process with :0 appeneded to contrail-api.

contrail-api:0 STARTING
contrail-device-manager RUNNING pid 17534, uptime 9:56:17
contrail-discovery:0 RUNNING pid 17531, uptime 9:56:17
contrail-schema RUNNING pid 17533, uptime 9:56:17
contrail-svc-monitor RUNNING pid 17535, uptime 9:56:17

Whereas the init,d file has this

supervisorctl -s unix:///tmp/supervisord_config.sock ${1} `basename ${0}`

hence it fails as there is no process registered in supervisor named contrail-api

This affects the contrail-discovery process as well.